### PR TITLE
Fix environment variable for build folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Call ``build-docs.sh``. QGIS python package must be found.
 You can either:
 
 * export the PYTHONPATH yourself
-* export your QGIS build directory with ``export QGIS-BUILD-DIR=/Users/timlinux/dev/QGIS/build``
+* export your QGIS build directory with ``export QGIS_BUILD_DIR=/Users/timlinux/dev/QGIS/build``
 * or provide QGIS build directory as argument to the script: ``./build-docs.sh -qgis-build-dir /Users/timlinux/dev/QGIS/build``
 
 ## Viewing the docs


### PR DESCRIPTION
to match the one used in scripts

https://github.com/qgis/pyqgis/blob/30c4a17f818795383600a3712475c28e808f8980/scripts/build-docs.sh#L43-L46

```sh
if [[ -n ${QGIS_BUILD_DIR} ]]; then
  export PYTHONPATH=${PYTHONPATH}:$QGIS_BUILD_DIR/output/python
  #export PATH=$PATH:/usr/local/bin/:$QGIS_BUILD_DIR/build/output/bin
fi
```